### PR TITLE
Fix File not found error

### DIFF
--- a/src/content/adb.jsm
+++ b/src/content/adb.jsm
@@ -10,7 +10,7 @@ let Cu = Components.utils;
 let CC = Components.Constructor;
 
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/commonjs/promise/core.js");
+Cu.import("resource://gre/modules/commonjs/sdk/core/promise.js");
 Cu.import("resource://gre/modules/osfile.jsm");
 
 this.EXPORTED_SYMBOLS = ["ADB"];

--- a/src/content/debugger.jsm
+++ b/src/content/debugger.jsm
@@ -7,7 +7,7 @@ let Ci = Components.interfaces;
 let Cu = Components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/commonjs/promise/core.js");
+Cu.import("resource://gre/modules/commonjs/sdk/core/promise.js");
 Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 
 this.EXPORTED_SYMBOLS = ["Debugger"];

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -8,7 +8,7 @@ let Cu = Components.utils;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/commonjs/promise/core.js");
+Cu.import("resource://gre/modules/commonjs/sdk/core/promise.js");
 Cu.import("chrome://b2g-remote/content/adb.jsm");
 Cu.import("chrome://b2g-remote/content/debugger.jsm");
 Cu.import("resource://gre/modules/osfile.jsm");


### PR DESCRIPTION
Looks like promise/core.js was renamed to sdk/core/promise.js ???
http://mxr.mozilla.org/mozilla-central/search?find=%2F&string=commonjs

After this fix, I was able to load a packaged app on device!
