### PR TITLE
support new TCPSocket API; revert to nsIProcess to fix regression

### DIFF
--- a/src/content/adb.jsm
+++ b/src/content/adb.jsm
@@ -23,13 +23,6 @@ let Cu = components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
-let subprocess;
-if (COMMONJS) {
-  subprocess = require("subprocess");
-} else {
-  Cu.import("chrome://b2g-remote/content/subprocess.jsm");
-}
-
 // Get the TextEncoder and TextDecoder interfaces from the hidden window,
 // since they aren't defined in a CommonJS module by default.
 let hiddenWindow = Cc['@mozilla.org/appshell/appShellService;1']
@@ -43,6 +36,9 @@ try {
   Cu.import("resource://gre/modules/commonjs/sdk/core/promise.js");
 }
 Cu.import("resource://gre/modules/osfile.jsm");
+
+const OLD_SOCKET_API =
+  Services.vc.compare(Services.appinfo.platformVersion, "23.0a1") < 0;
 
 if (!COMMONJS) {
   this.EXPORTED_SYMBOLS = ["ADB"];
@@ -117,32 +113,25 @@ this.ADB = {
   // We startup by launching adb in server mode, and setting
   // the tcp socket preference to |true|
   start: function adb_start() {
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["start-server"];
     let self = this;
-
-    subprocess.call({
-      command: this._adb.path,
-
-      arguments: ["start-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("start-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
-          self.ready = true;
-          Services.obs.notifyObservers(null, "adb-ready", null);
-        } else {
-          self.ready = false;
-        }
-      }
-    });
+    process.runAsync(params, params.length, {
+      observe: function(aSubject, aTopic, aData) {
+        switch(aTopic) {
+          case "process-finished":
+            Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
+            Services.obs.notifyObservers(null, "adb-ready", null);
+            self.ready = true;
+            break;
+          case "process-failed":
+            self.ready = false;
+            break;
+         }
+       }
+    }, false);
   },
 
   /**
@@ -158,41 +147,37 @@ this.ADB = {
    *        the update doesn't race the killing.
    */
   kill: function adb_kill(aSync) {
-    let process = subprocess.call({
-      command: this._adb.path,
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["kill-server"];
 
-      arguments: ["kill-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("kill-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else if (result.exitCode == 1) {
-          // This is a known problem.  For some reason, adb kill-server
-          // frequently writes "* server not running *" and exits with code 1
-          // even though the server process was running, and it killed it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else {
-          // It's hard to say whether or not ADB is ready at this point,
-          // but it seems safer to assume that it isn't, so code that wants
-          // to use it later will try to restart it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        }
-      }
-    });
     if (aSync) {
-      process.wait();
+      process.run(true, params, params.length);
+      debug("adb kill-server: " + process.exitValue);
+      this.ready = false;
+    }
+    else {
+      let self = this;
+      process.runAsync(params, params.length, {
+        observe: function(aSubject, aTopic, aData) {
+          switch(aTopic) {
+            case "process-finished":
+              debug("adb kill-server: " + process.exitValue);
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+            case "process-failed":
+              debug("adb kill-server failure: " + process.exitValue);
+              // It's hard to say whether or not ADB is ready at this point,
+              // but it seems safer to assume that it isn't, so code that wants
+              // to use it later will try to restart it.
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+          }
+        }
+      }, false);
     }
   },
 
@@ -227,7 +212,8 @@ this.ADB = {
   _checkResponse: function adb_checkResponse(aPacket) {
     const OKAY = 0x59414b4f; // OKAY
     const FAIL = 0x4c494146; // FAIL
-    let view = new Uint32Array(aPacket.buffer, 0 , 1);
+    let buffer = OLD_SOCKET_API ? aPacket.buffer : aPacket;
+    let view = new Uint32Array(buffer, 0 , 1);
     if (view[0] == FAIL) {
       debug("Response: FAIL");
     }
@@ -238,10 +224,11 @@ this.ADB = {
   // @param aIgnoreResponse True if this packet has no OKAY/FAIL.
   // @return                A js object { length:...; data:... }
   _unpackPacket: function adb_unpackPacket(aPacket, aIgnoreResponse) {
-    let lengthView = new Uint8Array(aPacket.buffer, aIgnoreResponse ? 0 : 4, 4);
+    let buffer = OLD_SOCKET_API ? aPacket.buffer : aPacket;
+    let lengthView = new Uint8Array(buffer, aIgnoreResponse ? 0 : 4, 4);
     let decoder = new TextDecoder();
     let length = parseInt(decoder.decode(lengthView), 16);
-    let text = new Uint8Array(aPacket.buffer, aIgnoreResponse ? 4 : 8, length);
+    let text = new Uint8Array(buffer, aIgnoreResponse ? 4 : 8, length);
     return { length: length, data: decoder.decode(text) }
   },
 
@@ -258,7 +245,7 @@ this.ADB = {
       debug("trackDevices onopen");
       Services.obs.notifyObservers(null, "adb-track-devices-start", null);
       let req = this._createRequest("host:track-devices");
-      socket.send(req);
+      ADB.sockSend(socket, req);
 
     }.bind(this);
 
@@ -275,9 +262,9 @@ this.ADB = {
     socket.ondata = function(aEvent) {
       debug("trackDevices ondata");
       let data = aEvent.data;
-      debug("length=" + data.length);
+      debug("length=" + data.byteLength);
       let dec = new TextDecoder();
-      debug(dec.decode(data).trim());
+      debug(dec.decode(new Uint8Array(data)).trim());
 
       // check the OKAY or FAIL on first packet.
       if (waitForFirst) {
@@ -414,23 +401,29 @@ this.ADB = {
     return deferred.promise;
   },
 
-  // debugging version of tcpsocket.send()
-  sockSend: function adb_sockSend(aSocket, aArray) {
-    let decoder = new TextDecoder();
-    let s = decoder.decode(aArray);
-    let len = aArray.length;
+  /**
+   * Dump the first few bytes of the given array to the console.
+   *
+   * @param {TypedArray} aArray
+   *        the array to dump
+   */
+  hexdump: function adb_hexdump(aArray) {
+    let decoder = new TextDecoder("windows-1252");
+    let array = new Uint8Array(aArray.buffer);
+    let s = decoder.decode(array);
+    let len = array.length;
     let dbg = "len=" + len + " ";
     let l = len > 20 ? 20 : len;
 
     for (let i = 0; i < l; i++) {
-      let c = aArray[i].toString(16);
+      let c = array[i].toString(16);
       if (c.length == 1)
         c = "0" + c;
       dbg += c;
     }
     dbg += " ";
     for (let i = 0; i < l; i++) {
-      let c = aArray[i];
+      let c = array[i];
       if (c < 32 || c > 127) {
         dbg += ".";
       } else {
@@ -438,7 +431,19 @@ this.ADB = {
       }
     }
     debug(dbg);
-    aSocket.send(aArray);
+  },
+
+  // debugging version of tcpsocket.send()
+  sockSend: function adb_sockSend(aSocket, aArray) {
+    this.hexdump(aArray);
+
+    if (OLD_SOCKET_API) {
+      // Create a new Uint8Array in case the array we got is of a different type
+      // (like Uint32Array), since the old API takes a Uint8Array.
+      aSocket.send(new Uint8Array(aArray.buffer));
+    } else {
+      aSocket.send(aArray.buffer, aArray.byteOffset, aArray.byteLength);
+    }
   },
 
   // pushes a file to the device.
@@ -472,7 +477,7 @@ this.ADB = {
           break;
         case "send-transport":
           req = ADB._createRequest("host:transport-any");
-          socket.send(req);
+          ADB.sockSend(socket, req);
           state = "wait-transport";
           break
         case "wait-transport":
@@ -486,7 +491,7 @@ this.ADB = {
           break
         case "send-sync":
           req = ADB._createRequest("sync:");
-          socket.send(req);
+          ADB.sockSend(socket, req);
           state = "wait-sync";
           break
         case "wait-sync":
@@ -502,30 +507,41 @@ this.ADB = {
           // need to send SEND + length($aDest,$fileMode)
           // $fileMode is not the octal one there.
           let encoder = new TextEncoder();
-          let uint32Packet = new Uint32Array(1);
-          let uint8Packet = new Uint8Array(uint32Packet.buffer, 0, 4);
-          ADB.sockSend(socket, encoder.encode("SEND"));
-          let info = aDest + ",33204";
-          uint32Packet[0] = info.length;
-          ADB.sockSend(socket, uint8Packet);
-          ADB.sockSend(socket, encoder.encode(info));
+
+          let (infoLengthPacket = new Uint32Array(1), info = aDest + ",33204") {
+            infoLengthPacket[0] = info.length;
+            ADB.sockSend(socket, encoder.encode("SEND"));
+            ADB.sockSend(socket, infoLengthPacket);
+            ADB.sockSend(socket, encoder.encode(info));
+          }
 
           // now sending file data.
           while (remaining > 0) {
             let toSend = remaining > 65536 ? 65536 : remaining;
             debug("Sending " + toSend + " bytes");
+
+            let dataLengthPacket = new Uint32Array(1);
+            // We have to create a new ArrayBuffer for the fileData slice
+            // because nsIDOMTCPSocket (or ArrayBufferInputStream) chokes on
+            // reused buffers, even when we don't modify their contents.
+            let dataPacket = new Uint8Array(new ArrayBuffer(toSend));
+            dataPacket.set(new Uint8Array(fileData.buffer, currentPos, toSend));
+            dataLengthPacket[0] = toSend;
             ADB.sockSend(socket, encoder.encode("DATA"));
-            uint32Packet[0] = toSend;
-            ADB.sockSend(socket, uint8Packet);
-            ADB.sockSend(socket, new Uint8Array(fileData.buffer, currentPos, toSend));
+            ADB.sockSend(socket, dataLengthPacket);
+            ADB.sockSend(socket, dataPacket);
+
             currentPos += toSend;
             remaining -= toSend;
           }
 
           // Ending up with DONE + mtime (wtf???)
-          socket.send(encoder.encode("DONE"));
-          uint32Packet[0] = fileTime;
-          socket.send(uint8Packet);
+          let (fileTimePacket = new Uint32Array(1)) {
+            fileTimePacket[0] = fileTime;
+            ADB.sockSend(socket, encoder.encode("DONE"));
+            ADB.sockSend(socket, fileTimePacket);
+          }
+
           state = "wait-done";
           break;
         case "wait-done":
@@ -623,7 +639,7 @@ this.ADB = {
     socket.onopen = function() {
       debug("runCommand onopen");
       let req = this._createRequest(aCommand);
-      socket.send(req);
+      ADB.sockSend(socket, req);
 
     }.bind(this);
 


### PR DESCRIPTION
The primary purpose of this changeset is to support the new TCPSocket API and implementation ([bug 831107](https://bugzilla.mozilla.org/show_bug.cgi?id=831107)), which landed on mozilla-central last Friday and broke all consumers of the old API.

But the changeset has to do more than simply update API calls, because the implementation also changed in two important ways:
- Due to buffering in the new implementation, it isn't possible to reuse ArrayBuffer objects to send multiple packets, as mutations of buffers you previously sent will modify the data you previously sent.
- Due to [bug 865652](https://bugzilla.mozilla.org/show_bug.cgi?id=865652), you can't use offset/length arguments to send portions of buffers.

The latter issue will get fixed, but the former issue is an inherent limitation in the new implementation and must be observed. So this changeset creates a new buffer for each packet it sends.

Along the way, it also improves logging in a couple ways:
- It routes all packets through the _socksend_ function, so all of them are logged.
- The _socksend_ function logs packets by converting them to two representations: a binary "hexdump" and its ASCII equivalent. The latter is done using a TextDecoder, but the charset of the decoder was the default (UTF-8), which treats some bytes as part of multi-byte encodings and decodes them to a single character, which can make the array of characters get out of sync with the array bytes they represent. So I changed the charset to Windows-1252, which is also ASCII-compatible but is a single-byte encoding.

Finally, this changeset reverts from _subprocess_ back to _nsIProcess_ for starting/stopping adb. In further tests with the Simulator, @ochameau and I identified a serious regression with using _subprocess_: it doesn't always notice that adb has exited, probably because adb forks a server process that holds open the stdout/stderr file handles.

_nsIProcess_ has its own problems, especially on Windows, where it opens a console window when you start it. But we're still better off using it until we can resolve that issue with _subprocess_. @ochameau is looking into it. In the meantime, I didn't remove the _subprocess_ module from B2GRemote, as I assume we'll start using it again after we resolve the issue.
