### PR TITLE
Added a Makefile for building b2gremote.xpi from src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+b2gremote.xpi

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.swp
 b2gremote.xpi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+SRC_FILES=$(shell find src/ -type f)
+
+b2gremote.xpi: $(SRC_FILES)
+	cd src; zip -r ../b2gremote.xpi *


### PR DESCRIPTION
Added both a `Makefile` and `.gitignore`.

One can use:

```
$ make
```

inside project directory to build `b2gremote.xpi`.

Prerequisites: _make_, _zip_.
