### PR TITLE
Reuse running adb instead of killing existing one

### DIFF
--- a/src/content/adb.jsm
+++ b/src/content/adb.jsm
@@ -11,7 +11,7 @@
 // then it's a JavaScript Module.
 const COMMONJS = ("require" in this);
 
-let components;
+let components, subprocess, file, env;
 if (COMMONJS) {
   components = require("chrome").components;
 } else {
@@ -21,14 +21,41 @@ let Cc = components.classes;
 let Ci = components.interfaces;
 let Cu = components.utils;
 
+if (COMMONJS) {
+  subprocess = require("subprocess");
+  file = require("file");
+  env = require("api-utils/environment").env;
+} else {
+  Cu.import("chrome://b2g-remote/content/subprocess.jsm");
+  let { Loader, Require } =
+    Cu.import('resource://gre/modules/commonjs/toolkit/loader.js').Loader;
+
+  let loader = Loader({
+    paths: {
+      '': 'resource://gre/modules/commonjs/sdk/'
+    },
+    globals: { },
+    modules: { }
+  });
+
+  // This variable needs to be named something other than require or else
+  // the addon-sdk loader gets confused. The addon-sdk throws a
+  // ModuleNotFoundError at addon build time. For example:
+  //
+  // ModuleNotFoundError: unable to satisfy: require(io/file) from...
+  let require_ = Require(loader);
+
+  file = require_("io/file");
+  env = require_("system/environment").env;
+}
 Cu.import("resource://gre/modules/Services.jsm");
 
-// Get the TextEncoder and TextDecoder interfaces from the hidden window,
-// since they aren't defined in a CommonJS module by default.
-let hiddenWindow = Cc['@mozilla.org/appshell/appShellService;1']
-                     .getService(Ci.nsIAppShellService).hiddenDOMWindow;
-let TextEncoder = COMMONJS ? hiddenWindow.TextEncoder : TextEncoder;
-let TextDecoder = COMMONJS ? hiddenWindow.TextDecoder : TextDecoder;
+// When loaded as a CommonJS module, get the TextEncoder and TextDecoder
+// interfaces from the Services JavaScript Module, since they aren't defined
+// in a CommonJS module by default.
+let { TextEncoder, TextDecoder } =
+  COMMONJS ? Cu.import("resource://gre/modules/Services.jsm", {})
+           : { TextEncoder: TextEncoder, TextDecoder: TextDecoder };
 
 try {
   Cu.import("resource://gre/modules/commonjs/promise/core.js");
@@ -53,8 +80,13 @@ function debug(aStr) {
 }
 
 let ready = false;
+let didRunInitially = false;
+const psRegexNix = /.*? \d+ .*? .*? \d+\s+\d+ .*? .*? .*? .*? adb .*fork\-server/;
+const psRegexWin = /adb.exe.*/;
 
 this.ADB = {
+  get didRunInitially() didRunInitially,
+  set didRunInitially(newVal) { didRunInitially = newVal },
   get ready() ready,
   set ready(newVal) { ready = newVal },
 
@@ -113,25 +145,41 @@ this.ADB = {
   // We startup by launching adb in server mode, and setting
   // the tcp socket preference to |true|
   start: function adb_start() {
-    let process = Cc["@mozilla.org/process/util;1"]
-                    .createInstance(Ci.nsIProcess);
-    process.init(this._adb);
-    let params = ["start-server"];
-    let self = this;
-    process.runAsync(params, params.length, {
-      observe: function(aSubject, aTopic, aData) {
-        switch(aTopic) {
-          case "process-finished":
-            Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
-            Services.obs.notifyObservers(null, "adb-ready", null);
-            self.ready = true;
-            break;
-          case "process-failed":
-            self.ready = false;
-            break;
-         }
-       }
-    }, false);
+    let onSuccessfulStart = (function onSuccessfulStart() {
+      Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
+      Services.obs.notifyObservers(null, "adb-ready", null);
+      this.ready = true;
+    }).bind(this);
+
+    this._isAdbRunning().then(
+      (function onSuccess(isAdbRunning) {
+        if (isAdbRunning) {
+          this.didRunInitially = false;
+          debug("Found ADB process running, not restarting");
+          onSuccessfulStart();
+          return;
+        }
+        debug("Didn't find ADB process running, restarting");
+
+        this.didRunInitially = true;
+        let process = Cc["@mozilla.org/process/util;1"]
+                        .createInstance(Ci.nsIProcess);
+        process.init(this._adb);
+        let params = ["start-server"];
+        let self = this;
+        process.runAsync(params, params.length, {
+          observe: function(aSubject, aTopic, aData) {
+            switch(aTopic) {
+              case "process-finished":
+                onSuccessfulStart();
+                break;
+              case "process-failed":
+                self.ready = false;
+                break;
+             }
+           }
+        }, false);
+      }).bind(this));
   },
 
   /**
@@ -156,6 +204,7 @@ this.ADB = {
       process.run(true, params, params.length);
       debug("adb kill-server: " + process.exitValue);
       this.ready = false;
+      this.didRunInitially = false;
     }
     else {
       let self = this;
@@ -166,6 +215,7 @@ this.ADB = {
               debug("adb kill-server: " + process.exitValue);
               Services.obs.notifyObservers(null, "adb-killed", null);
               self.ready = false;
+              self.didRunInitially = false;
               break;
             case "process-failed":
               debug("adb kill-server failure: " + process.exitValue);
@@ -174,11 +224,61 @@ this.ADB = {
               // to use it later will try to restart it.
               Services.obs.notifyObservers(null, "adb-killed", null);
               self.ready = false;
+              self.didRunInitially = false;
               break;
           }
         }
       }, false);
     }
+  },
+
+  _isAdbRunning: function() {
+    let deferred = Promise.defer();
+
+    let ps, args;
+    let platform = Services.appinfo.OS;
+    if (platform === "WINNT") {
+      ps = "C:\\windows\\system32\\tasklist.exe";
+      args = [];
+    } else {
+      args = ["aux"];
+      let psCommand = "ps";
+
+      let paths = env.PATH.split(':');
+      let len = paths.length;
+      for (let i = 0; i < len; i++) {
+        let fullyQualified = file.join(paths[i], psCommand);
+        if (file.exists(fullyQualified)) {
+          ps = fullyQualified;
+          break;
+        }
+      }
+      if (!ps) {
+        debug("Error: a task list executable not found on filesystem");
+        deferred.resolve(false); // default to restart adb
+        return deferred.promise;
+      }
+    }
+
+    let buffer = [];
+
+    subprocess.call({
+      command: ps,
+      arguments: args,
+      stdout: function(data) {
+        buffer.push(data);
+      },
+      done: function() {
+        let lines = buffer.join('').split('\n');
+        let regex = (platform === "WINNT") ? psRegexWin : psRegexNix;
+        let isAdbRunning = lines.some(function(line) {
+          return regex.test(line);
+        });
+        deferred.resolve(isAdbRunning);
+      }
+    });
+
+    return deferred.promise;
   },
 
   // Creates a socket connected to the adb instance.


### PR DESCRIPTION
This patch modifies the ADB API to attempt to reuse a running `adb` process if one exists.

b2gremote seems to behave the same for me before and after this commit (with and without `adb` having been running before opening b2gremote after the change).

See https://github.com/mozilla/r2d2b2g/pull/584
